### PR TITLE
fix(config): add google analytics tracking code

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -30,7 +30,9 @@ module.exports = {
       },
     ],
   ],
+  themeConfig: {
     googleAnalytics: {
       trackingID: "UA-173987-66",
-    },
+    }
+  }
 };


### PR DESCRIPTION
Fixes docusaurus config for gogle analytics tracking code