### PR TITLE
fix: keyboard navigation bar accessibility

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -425,6 +425,50 @@ input:checked + .slider:before {
   opacity: 1;
 }
 
+.navBarItemTab:focus-within .dropDownMenu{
+  visibility: visible;
+  display: block;
+}
+
+.navBarItemTab:focus-within .dropDownMenu::after{
+  top: 0;
+  right: auto;
+  height: 100%;
+  width: 150px;
+}
+
+.navBarItemTab:focus-within .dropDownMenuActive{
+  visibility: visible;
+  display: block;
+}
+
+.navBarItemTab:focus-within .dropDownMenuActive::after{
+  top: 0;
+  right: auto;
+  height: 100%;
+  width: 150px;
+}
+
+.navBarItemTab:focus-within .dropDownMenu .menuItemDrop{
+  transition-delay:  0.3s;
+  opacity: 1;
+}
+
+.navBarItemTab:focus-within .link:after{
+  left:  0;
+  width: 100%;
+}
+
+#boxMenuItems:focus-within .linkActive::after{
+  left:  0;
+  width: 0%;
+}
+
+#boxMenuItems:focus-within .navBarItemTab:focus-within .linkActive::after{
+  left:  0;
+  width: 100%;
+}
+
 .dropDownMenu{
   position: absolute;
   display: block;

--- a/src/theme/Navbar.js
+++ b/src/theme/Navbar.js
@@ -189,25 +189,27 @@ const NavbarMenu = () => {
                     {PATHS.map((item) => (
                       <Box key={item.label}>
                         {!item.dropDown && 
-                          <Link href={useBaseUrl(item.path)} target={item.target} key={item.label} style={{textDecoration:'none'}}>
+                          <Link className={"navBarItemTab"} href={useBaseUrl(item.path)} target={item.target} key={item.label} style={{textDecoration:'none'}}>
                             <Box className={"menuItem"}>  
                               <h5 className={clsx("link",{["linkActive"] : pathname === item.path})}>{item.label}</h5>                  
                             </Box>
                           </Link>
                         }
                         {item.dropDown && 
-                          <Box className={"menuItem"}>  
-                            <h5 className={clsx("link",{["linkActive"] : isCurrentPath(item.subPaths)})}>{item.label}</h5>
-                            <Box className={clsx("dropDownMenu",{["dropDownMenuActive"] : isCurrentPath(item.subPaths)})}  style={{width:item.markerSize}}>
-                                {item.subPaths.map((subItem) => (
-                                  <Link href={useBaseUrl(subItem.path)} target={subItem.target}  key={subItem.label} style={{textDecoration:'none'}}>
-                                    <Box>  
-                                      <h5 className={clsx("menuItemDrop",{["menuItemDropActive"] : pathname === subItem.path})} >{subItem.label}</h5>                  
-                                    </Box>
-                                  </Link>
-                                ))}
-                            </Box>                    
-                          </Box>
+                          <Link className={"navBarItemTab"}  href={useBaseUrl(item.path)} style={{textDecoration:'none'}}>
+                            <Box className={"menuItem"}>  
+                                <h5 className={clsx("link",{["linkActive"] : isCurrentPath(item.subPaths)})}>{item.label}</h5>
+                              <Box className={clsx("dropDownMenu",{["dropDownMenuActive"] : isCurrentPath(item.subPaths)})}  style={{width:item.markerSize}}>
+                                  {item.subPaths.map((subItem) => (
+                                    <Link className={"navBarItemTab"} href={useBaseUrl(subItem.path)} target={subItem.target}  key={subItem.label} style={{textDecoration:'none'}}>
+                                      <Box>  
+                                        <h5 className={clsx("menuItemDrop",{["menuItemDropActive"] : pathname === subItem.path})} >{subItem.label}</h5>                  
+                                      </Box>
+                                    </Link>
+                                  ))}
+                              </Box>                    
+                            </Box>
+                          </Link>
                         }
                       </Box>
                     ))}


### PR DESCRIPTION
closes #164

# What does this PR do?
- allow tab navigation on dropdowns

# Steps to test
- yarn start
- go to http://localhost:3000/
- navigate in navbar with keyboard
